### PR TITLE
Add OpenRouter support for multi-model AI commit generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lazycommitt",
-  "version": "1.0.19",
-  "description": "Writes your git commit messages for you with AI using Groq",
+  "version": "1.1.0",
+  "description": "Writes your git commit messages for you with AI using Groq or OpenRouter (100+ models)",
   "main": "index.js",
   "scripts": {
     "build": "pkgroll --minify",
@@ -15,6 +15,10 @@
     "commit",
     "ai",
     "groq",
+    "openrouter",
+    "claude",
+    "gpt",
+    "llama",
     "github",
     "cli"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,8 +455,8 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
-  '@types/node@18.19.126':
-    resolution: {integrity: sha512-8AXQlBfrGmtYJEJUPs63F/uZQqVeFiN9o6NUjbDJYfxNxFnArlZufANPw4h6dGhYGKxcyw+TapXFvEsguzIQow==}
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@24.5.1':
     resolution: {integrity: sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==}
@@ -642,8 +642,8 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   formdata-node@4.4.1:
@@ -1277,9 +1277,9 @@ snapshots:
   '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 24.5.1
-      form-data: 4.0.4
+      form-data: 4.0.5
 
-  '@types/node@18.19.126':
+  '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
 
@@ -1481,7 +1481,7 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.4:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -1538,7 +1538,7 @@ snapshots:
 
   groq-sdk@0.32.0:
     dependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0

--- a/src/utils/openrouter.ts
+++ b/src/utils/openrouter.ts
@@ -1,0 +1,254 @@
+import { KnownError } from './error.js';
+import type { CommitType } from './config.js';
+import { generatePrompt } from './prompt.js';
+
+interface OpenRouterMessage {
+	role: 'system' | 'user' | 'assistant';
+	content: string;
+}
+
+interface OpenRouterChoice {
+	message: {
+		content: string;
+		role: string;
+	};
+	finish_reason: string;
+	index: number;
+}
+
+interface OpenRouterResponse {
+	id: string;
+	choices: OpenRouterChoice[];
+	model: string;
+	usage?: {
+		prompt_tokens: number;
+		completion_tokens: number;
+		total_tokens: number;
+	};
+}
+
+interface OpenRouterError {
+	error: {
+		message: string;
+		type: string;
+		code?: string | number;
+	};
+}
+
+const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+const createChatCompletion = async (
+	apiKey: string,
+	model: string,
+	messages: OpenRouterMessage[],
+	temperature: number,
+	top_p: number,
+	frequency_penalty: number,
+	presence_penalty: number,
+	max_tokens: number,
+	n: number,
+	timeout: number,
+	proxy?: string
+): Promise<{ choices: OpenRouterChoice[] }> => {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+	try {
+		if (n > 1) {
+			// OpenRouter doesn't support n > 1, so we make multiple requests
+			const completions = await Promise.all(
+				Array.from({ length: n }, () =>
+					makeRequest(apiKey, model, messages, temperature, top_p, frequency_penalty, presence_penalty, max_tokens, timeout, proxy)
+				)
+			);
+			return {
+				choices: completions.flatMap(completion => completion.choices),
+			};
+		}
+
+		return await makeRequest(apiKey, model, messages, temperature, top_p, frequency_penalty, presence_penalty, max_tokens, timeout, proxy);
+	} finally {
+		clearTimeout(timeoutId);
+	}
+};
+
+const makeRequest = async (
+	apiKey: string,
+	model: string,
+	messages: OpenRouterMessage[],
+	temperature: number,
+	top_p: number,
+	frequency_penalty: number,
+	presence_penalty: number,
+	max_tokens: number,
+	timeout: number,
+	proxy?: string
+): Promise<OpenRouterResponse> => {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+	try {
+		const response = await fetch(OPENROUTER_API_URL, {
+			method: 'POST',
+			headers: {
+				'Authorization': `Bearer ${apiKey}`,
+				'Content-Type': 'application/json',
+				'HTTP-Referer': 'https://github.com/lazycommit',
+				'X-Title': 'lazycommit',
+			},
+			body: JSON.stringify({
+				model,
+				messages,
+				temperature,
+				top_p,
+				frequency_penalty,
+				presence_penalty,
+				max_tokens,
+			}),
+			signal: controller.signal,
+		});
+
+		if (!response.ok) {
+			const errorData = await response.json().catch(() => ({})) as OpenRouterError;
+			let errorMessage = `OpenRouter API Error: ${response.status}`;
+
+			if (errorData.error?.message) {
+				errorMessage += ` - ${errorData.error.message}`;
+			}
+
+			if (response.status === 401) {
+				errorMessage += '\n\nInvalid API key. Get your key from https://openrouter.ai/keys';
+			}
+
+			if (response.status === 402) {
+				errorMessage += '\n\nInsufficient credits. Add credits at https://openrouter.ai/credits';
+			}
+
+			if (response.status === 413 || response.status === 429) {
+				errorMessage += '\n\n💡 Tip: Your request is too large or rate limited. Try:\n' +
+					'1. Commit files in smaller batches\n' +
+					'2. Exclude large files with --exclude\n' +
+					'3. Use a different model\n' +
+					'4. Check if you have build artifacts staged (dist/, .next/, etc.)';
+			}
+
+			if (response.status >= 500) {
+				errorMessage += '\n\nOpenRouter server error. Check status at https://openrouter.ai';
+			}
+
+			throw new KnownError(errorMessage);
+		}
+
+		return await response.json() as OpenRouterResponse;
+	} catch (error: any) {
+		if (error instanceof KnownError) {
+			throw error;
+		}
+
+		if (error.name === 'AbortError') {
+			throw new KnownError(`Request timed out after ${timeout}ms. Try increasing timeout with: lazycommit config set timeout=20000`);
+		}
+
+		if (error.code === 'ENOTFOUND' || error.cause?.code === 'ENOTFOUND') {
+			throw new KnownError('Error connecting to OpenRouter. Are you connected to the internet?');
+		}
+
+		throw error;
+	} finally {
+		clearTimeout(timeoutId);
+	}
+};
+
+const sanitizeMessage = (message: string) =>
+	message
+		.trim()
+		.replace(/^["']|["']\.?$/g, '')
+		.replace(/[\n\r]/g, '')
+		.replace(/(\w)\.$/, '$1');
+
+const enforceMaxLength = (message: string, maxLength: number): string => {
+	if (message.length <= maxLength) return message;
+
+	const cut = message.slice(0, maxLength);
+
+	// Look for sentence endings first (., !, ?)
+	const sentenceEnd = Math.max(
+		cut.lastIndexOf('. '),
+		cut.lastIndexOf('! '),
+		cut.lastIndexOf('? ')
+	);
+
+	if (sentenceEnd > maxLength * 0.7) {
+		return cut.slice(0, sentenceEnd + 1);
+	}
+
+	// Look for comma or semicolon as secondary break point
+	const clauseEnd = Math.max(
+		cut.lastIndexOf(', '),
+		cut.lastIndexOf('; ')
+	);
+
+	if (clauseEnd > maxLength * 0.6) {
+		return cut.slice(0, clauseEnd + 1);
+	}
+
+	// Fall back to word boundary
+	const lastSpace = cut.lastIndexOf(' ');
+	if (lastSpace > maxLength * 0.5) {
+		return cut.slice(0, lastSpace);
+	}
+
+	// Last resort: hard cut but add ellipsis if it seems incomplete
+	if (message.length > maxLength + 10) {
+		return cut + '...';
+	}
+
+	return cut;
+};
+
+const deduplicateMessages = (array: string[]) => Array.from(new Set(array));
+
+export const generateCommitMessageFromSummary = async (
+	apiKey: string,
+	model: string,
+	locale: string,
+	summary: string,
+	completions: number,
+	maxLength: number,
+	type: CommitType,
+	timeout: number,
+	proxy?: string
+): Promise<string[]> => {
+	const prompt = summary;
+	const completion = await createChatCompletion(
+		apiKey,
+		model,
+		[
+			{ role: 'system', content: generatePrompt(locale, maxLength, type) },
+			{ role: 'user', content: prompt },
+		],
+		0.3, // Lower temperature for more consistent, focused responses
+		1,
+		0,
+		0,
+		Math.max(300, maxLength * 12),
+		completions,
+		timeout,
+		proxy
+	);
+
+	const messages = (completion.choices || [])
+		.map((c) => c.message?.content || '')
+		.map((t) => sanitizeMessage(t))
+		.filter(Boolean)
+		.map((t) => {
+			// Only enforce max length if significantly over limit
+			if (t.length > maxLength * 1.1) {
+				return enforceMaxLength(t, maxLength);
+			}
+			return t;
+		})
+		.filter(msg => msg.length >= 10); // Ensure minimum meaningful length
+
+	return deduplicateMessages(messages);
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,4 +9,6 @@
 		"esModuleInterop": true,
 		"skipLibCheck": true
 	},
+	"include": ["src/**/*", "tests/**/*"],
+	"exclude": ["node_modules", "dist", "website"]
 }


### PR DESCRIPTION
## Summary
Adds OpenRouter as an alternative AI provider, giving users access to 100+ models (Claude, GPT-4, Llama, Mistral, Gemini, etc.) while maintaining full backward compatibility with Groq.

## Changes
- Added new `provider` config option (`groq` | `openrouter`)
- Created `src/utils/openrouter.ts` for OpenRouter API integration
- Updated config to support both `GROQ_API_KEY` and `OPENROUTER_API_KEY`
- Default model per provider: Groq uses `llama-3.1-8b-instant`, OpenRouter uses `anthropic/claude-3.5-sonnet`
- Updated CLI to dynamically select provider based on config
- Version bump to 1.1.0

## Usage
```bash
# Switch to OpenRouter
lazycommit config set provider=openrouter
lazycommit config set OPENROUTER_API_KEY=sk-or-your-key

# Use any OpenRouter model
lazycommit config set model=anthropic/claude-3.5-sonnet

# Switch back to Groq (default)
lazycommit config set provider=groq
