### PR TITLE
feat: add --yes and --no-verify flags to lazycommit CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,18 @@ cli(
 				alias: 's',
 				default: false,
 			},
+			yes: {
+				type: Boolean,
+				description: 'Skip approval and commit immediately',
+				alias: 'y',
+				default: false,
+			},
+			noVerify: {
+				type: Boolean,
+				description: 'Bypass pre-commit and commit-msg hooks',
+				alias: 'n',
+				default: false,
+			},
 		},
 
 		commands: [configCommand, hookCommand],
@@ -75,6 +87,8 @@ cli(
 				argv.flags.all,
 				argv.flags.type,
 				argv.flags.split,
+				argv.flags.yes,
+				argv.flags.noVerify,
 				rawArgv
 			);
 		}

--- a/tests/specs/cli/commits.ts
+++ b/tests/specs/cli/commits.ts
@@ -74,6 +74,30 @@ export default testSuite(({ describe }) => {
 			await fixture.rm();
 		});
 
+		test('Skips approval with --yes flag', async () => {
+			const { fixture, lazycommit } = await createFixture(files);
+			const git = await createGit(fixture.path);
+
+			await git('add', ['data.json']);
+
+			// With --yes, should commit immediately without prompts
+			await lazycommit(['--yes']);
+
+			const statusAfter = await git('status', [
+				'--porcelain',
+				'--untracked-files=no',
+			]);
+			expect(statusAfter.stdout).toBe('');
+
+			const { stdout: commitMessage } = await git('log', [
+				'--pretty=format:%s',
+			]);
+			expect(commitMessage).toBeTruthy();
+			expect(commitMessage?.length).toBeLessThanOrEqual(50);
+
+			await fixture.rm();
+		});
+
 		test('Generated commit message must be under 20 characters', async () => {
 			const { fixture, lazycommit } = await createFixture({
 				...files,

--- a/tests/specs/cli/index.ts
+++ b/tests/specs/cli/index.ts
@@ -4,5 +4,6 @@ export default testSuite(({ describe }) => {
 	describe('CLI', ({ runTestSuite }) => {
 		runTestSuite(import('./error-cases.js'));
 		runTestSuite(import('./commits.js'));
+    	runTestSuite(import('./no-verify.js'));
 	});
 });

--- a/tests/specs/cli/no-verify.ts
+++ b/tests/specs/cli/no-verify.ts
@@ -1,0 +1,39 @@
+import { testSuite, expect } from 'manten';
+import fs from 'fs/promises';
+import path from 'path';
+import {
+	assertGroqToken,
+	createFixture,
+	createGit,
+	files,
+} from '../../utils.js';
+
+export default testSuite(({ describe }) => {
+	describe('no-verify', async ({ test }) => {
+		if (!assertGroqToken()) {
+			return;
+		}
+
+		test('Bypasses pre-commit hook', async () => {
+			const { fixture, lazycommit } = await createFixture(files);
+			const git = await createGit(fixture.path);
+
+			// Create a pre-commit hook that fails
+			const hookPath = path.join(fixture.path, '.git/hooks/pre-commit');
+			await fs.writeFile(hookPath, '#!/bin/sh\nexit 1');
+			await fs.chmod(hookPath, '755');
+
+			await git('add', ['data.json']);
+
+			// Should fail without --no-verify
+			const { exitCode: failExitCode } = await lazycommit(['--yes'], { reject: false });
+			expect(failExitCode).toBe(1);
+
+			// Should pass with --no-verify
+			const { exitCode: successExitCode } = await lazycommit(['--no-verify', '--yes'], { reject: false });
+			expect(successExitCode).toBe(0);
+
+			await fixture.rm();
+		});
+	});
+});


### PR DESCRIPTION
## Add `--yes` and `--no-verify` flags

Adds two new CLI flags for improved automation and workflow flexibility:

- **`--yes` / `-y`**: Skip approval prompts and commit immediately
- **`--no-verify` / `-n`**: Bypass pre-commit and commit-msg hooks

Both flags can be used together and include comprehensive tests.